### PR TITLE
Proper `n` and `cap` URL PubSub parameters handling. Added `index` and `count` into the API.

### DIFF
--- a/dashboard.cc
+++ b/dashboard.cc
@@ -51,7 +51,9 @@ class ServeJSONOverHTTP {
   ServeJSONOverHTTP(Request r)
       : http_request_scope_(std::move(r)), http_response_(http_request_scope_.SendChunkedResponse()) {}
 
-  inline bool Entry(const T& entry) {
+  inline bool Entry(const T& entry, size_t index, size_t total) {
+    static_cast<void>(index);
+    static_cast<void>(total);
     try {
       http_response_(entry, "point");
       return true;

--- a/sherlock.h
+++ b/sherlock.h
@@ -126,6 +126,11 @@ class PubSubHTTPEndpoint {
       bricks::strings::FromString(http_request_.url.query["n"], n_);
       cap_ = n_;  // If `?n=` parameter is set, it sets `cap_` too by default. Use `?n=...&cap=0` to override.
     }
+    if (http_request_.url.query.has("n_min")) {
+      // `n_min` is same as `n`, but it does not set the cap; just the lower bound for `recent`.
+      serving_ = false;  // Start in 'non-serving' mode when `n_min` is set.
+      bricks::strings::FromString(http_request_.url.query["n_min"], n_);
+    }
     if (http_request_.url.query.has("cap")) {
       bricks::strings::FromString(http_request_.url.query["cap"], cap_);
     }

--- a/sherlock.h
+++ b/sherlock.h
@@ -124,8 +124,9 @@ class PubSubHTTPEndpoint {
     } else {
       serving_ = true;
     }
-    n_ = http_request_.url.query.has("n") ? bricks::strings::FromString<size_t>(http_request_.url.query["n"])
-                                          : 0;
+    cap_ = http_request_.url.query.has("cap")
+               ? bricks::strings::FromString<size_t>(http_request_.url.query["cap"])
+               : 0;
   }
 
   inline bool Entry(E& entry) {
@@ -140,9 +141,9 @@ class PubSubHTTPEndpoint {
       }
       if (serving_) {
         http_response_(entry, value_name_);
-        if (n_) {
-          --n_;
-          if (!n_) {
+        if (cap_) {
+          --cap_;
+          if (!cap_) {
             return false;
           }
         }
@@ -168,7 +169,7 @@ class PubSubHTTPEndpoint {
   // The logic to serve the stream starting from certain timestamp.
   bool serving_;
   bricks::time::EPOCH_MILLISECONDS from_timestamp_;
-  size_t n_;
+  size_t cap_;
 
   PubSubHTTPEndpoint() = delete;
   PubSubHTTPEndpoint(const PubSubHTTPEndpoint&) = delete;

--- a/test.cc
+++ b/test.cc
@@ -219,40 +219,40 @@ TEST(Sherlock, SubscribeToStreamViaHTTP) {
   HTTP(FLAGS_sherlock_http_test_port).ResetAllHandlers();
   HTTP(FLAGS_sherlock_http_test_port).Register("/exposed", exposed_stream);
   EXPECT_EQ(s[0] + s[1] + s[2] + s[3],
-            HTTP(GET(Printf("http://localhost:%d/exposed?n=4", FLAGS_sherlock_http_test_port))).body);
+            HTTP(GET(Printf("http://localhost:%d/exposed?cap=4", FLAGS_sherlock_http_test_port))).body);
   EXPECT_EQ(s[0] + s[1],
-            HTTP(GET(Printf("http://localhost:%d/exposed?n=2", FLAGS_sherlock_http_test_port))).body);
-  EXPECT_EQ(s[0], HTTP(GET(Printf("http://localhost:%d/exposed?n=1", FLAGS_sherlock_http_test_port))).body);
+            HTTP(GET(Printf("http://localhost:%d/exposed?cap=2", FLAGS_sherlock_http_test_port))).body);
+  EXPECT_EQ(s[0], HTTP(GET(Printf("http://localhost:%d/exposed?cap=1", FLAGS_sherlock_http_test_port))).body);
 
   EXPECT_EQ(
       s[3],
-      HTTP(GET(Printf("http://localhost:%d/exposed?n=1&recent=15000", FLAGS_sherlock_http_test_port))).body);
+      HTTP(GET(Printf("http://localhost:%d/exposed?cap=1&recent=15000", FLAGS_sherlock_http_test_port))).body);
   EXPECT_EQ(
       s[2],
-      HTTP(GET(Printf("http://localhost:%d/exposed?n=1&recent=25000", FLAGS_sherlock_http_test_port))).body);
+      HTTP(GET(Printf("http://localhost:%d/exposed?cap=1&recent=25000", FLAGS_sherlock_http_test_port))).body);
   EXPECT_EQ(
       s[1],
-      HTTP(GET(Printf("http://localhost:%d/exposed?n=1&recent=35000", FLAGS_sherlock_http_test_port))).body);
+      HTTP(GET(Printf("http://localhost:%d/exposed?cap=1&recent=35000", FLAGS_sherlock_http_test_port))).body);
   EXPECT_EQ(
       s[0],
-      HTTP(GET(Printf("http://localhost:%d/exposed?n=1&recent=45000", FLAGS_sherlock_http_test_port))).body);
+      HTTP(GET(Printf("http://localhost:%d/exposed?cap=1&recent=45000", FLAGS_sherlock_http_test_port))).body);
 
   EXPECT_EQ(
       s[2] + s[3],
-      HTTP(GET(Printf("http://localhost:%d/exposed?n=2&recent=25000", FLAGS_sherlock_http_test_port))).body);
+      HTTP(GET(Printf("http://localhost:%d/exposed?cap=2&recent=25000", FLAGS_sherlock_http_test_port))).body);
   EXPECT_EQ(
       s[1] + s[2],
-      HTTP(GET(Printf("http://localhost:%d/exposed?n=2&recent=35000", FLAGS_sherlock_http_test_port))).body);
+      HTTP(GET(Printf("http://localhost:%d/exposed?cap=2&recent=35000", FLAGS_sherlock_http_test_port))).body);
   EXPECT_EQ(
       s[0] + s[1],
-      HTTP(GET(Printf("http://localhost:%d/exposed?n=2&recent=45000", FLAGS_sherlock_http_test_port))).body);
+      HTTP(GET(Printf("http://localhost:%d/exposed?cap=2&recent=45000", FLAGS_sherlock_http_test_port))).body);
 
   EXPECT_EQ(
       s[1] + s[2] + s[3],
-      HTTP(GET(Printf("http://localhost:%d/exposed?n=3&recent=35000", FLAGS_sherlock_http_test_port))).body);
+      HTTP(GET(Printf("http://localhost:%d/exposed?cap=3&recent=35000", FLAGS_sherlock_http_test_port))).body);
   EXPECT_EQ(
       s[0] + s[1] + s[2],
-      HTTP(GET(Printf("http://localhost:%d/exposed?n=3&recent=45000", FLAGS_sherlock_http_test_port))).body);
+      HTTP(GET(Printf("http://localhost:%d/exposed?cap=3&recent=45000", FLAGS_sherlock_http_test_port))).body);
 
   // TODO(dkorolev): Unregister the exposed endpoint and free its handler. It's hanging out there now...
 }


### PR DESCRIPTION
CC @sompylasar, @mzhurovich.
