### PR TITLE
Shortened the test

### DIFF
--- a/yoda/policy.h
+++ b/yoda/policy.h
@@ -83,7 +83,7 @@ template <typename T_KEY, typename T_ENTRY, typename UNUSED_T_KEY_NOT_FOUND_EXCE
 struct SetPromiseToNullEntryOrThrow<T_KEY, T_ENTRY, UNUSED_T_KEY_NOT_FOUND_EXCEPTION, true> {
   static void DoIt(const T_KEY& key, std::promise<T_ENTRY>& pr) {
     T_ENTRY null_entry(NullEntry);
-    null_entry.set_key(key);
+    SetKey(null_entry, key);
     pr.set_value(null_entry);
   }
 };

--- a/yoda/test.cc
+++ b/yoda/test.cc
@@ -205,8 +205,9 @@ TEST(Sherlock, NonPolymorphicKeyValueStorage) {
   api.AsyncAdd(TestAPI::T_ENTRY(7, 0.0),
                std::bind(&CallbackTest::added, &cbt4),
                std::bind(&CallbackTest::already_exists, &cbt4));
-  while (!cbt4.called)
-    ;
+  while (!cbt4.called) {
+    ;  // Spin lock.
+  }
 
   // Thanks to eventual consistency, we don't have to wait until the above calls fully propagate.
   // Even if the next two lines run before the entries are published into the stream,

--- a/yoda/test.cc
+++ b/yoda/test.cc
@@ -131,7 +131,7 @@ TEST(Sherlock, NonPolymorphicKeyValueStorage) {
       EXPECT_EQ(key, entry.key);
       EXPECT_EQ(value, entry.value);
     }
-    void not_found(int key) const {
+    void not_found(const int key) const {
       ASSERT_FALSE(called);
       called = true;
       EXPECT_FALSE(expect_success);

--- a/yoda/yoda.h
+++ b/yoda/yoda.h
@@ -180,7 +180,7 @@ class API {
     virtual void DoIt(Storage& storage, T_STREAM_TYPE&) {
       // TODO(max+dima): Ensure that this storage update can't break
       // the actual state of the data.
-      storage.data[entry.key()] = entry;
+      storage.data[GetKey(entry)] = entry;
     }
   };
 
@@ -240,7 +240,7 @@ class API {
     // that might not yet have reached the storage, and thus relying on the fact that an API `Get()` call
     // reflects updated data is not reliable from the point of data synchronization.
     virtual void DoIt(Storage& storage, T_STREAM_TYPE& stream) {
-      const bool key_exists = static_cast<bool>(storage.data.count(e.key()));
+      const bool key_exists = static_cast<bool>(storage.data.count(GetKey(e)));
       if (key_exists && !T_POLICY::allow_overwrite_on_add) {
         if (on_failure) {  // Callback function defined.
           on_failure();
@@ -248,7 +248,7 @@ class API {
           pr.set_exception(std::make_exception_ptr(T_KEY_ALREADY_EXISTS_EXCEPTION(e)));
         }
       } else {
-        storage.data[e.key()] = e;
+        storage.data[GetKey(e)] = e;
         stream.Publish(e);
         if (on_success) {
           on_success();


### PR DESCRIPTION
(Please review after https://github.com/KnowSheet/Sherlock/pull/18)

Make it possible to shorten the test -- and did so -- by eliminating the need in `key()` and `set_key()` when the field storing the key is called just `key`.

Polymorphism coming tomorrow.

Thanks,
Dima
