### PR TITLE
A bunch of `std::forward<>`-s and related.

### DIFF
--- a/sherlock.h
+++ b/sherlock.h
@@ -313,11 +313,6 @@ class StreamInstanceImpl {
     scope->emplace_back(entry_params...);
   }
 
-  template <typename E>
-  void PublishPolymorphic(const E& polymorphic_entry) {
-    data_.MutableUse([&polymorphic_entry](std::vector<T>& data) { data.emplace_back(polymorphic_entry); });
-  }
-
   // `ListenerThread` spawns the thread and runs stream listener within it.
   //
   // Listener thread can always be `std::thread::join()`-ed. When this happens, the listener itself is notified
@@ -608,7 +603,8 @@ struct StreamInstance {
   // TODO(dkorolev): Perhaps eliminate the copy.
   template <typename E>
   typename std::enable_if<can_be_stored_in_unique_ptr<T, E>::value>::type Publish(const E& polymorphic_entry) {
-    impl_->PublishPolymorphic(new E(polymorphic_entry));
+    // TODO(dkorolev): Don't rely on the existence of copy constructor.
+    impl_->Emplace(new E(polymorphic_entry));
   }
 
   template <typename F>

--- a/yoda/api/key_entry/exceptions.h
+++ b/yoda/api/key_entry/exceptions.h
@@ -54,8 +54,9 @@ struct KeyAlreadyExistsCoverException : bricks::Exception {};
 template <typename ENTRY>
 struct KeyAlreadyExistsException : KeyAlreadyExistsCoverException {
   typedef ENTRY T_ENTRY;
-  const ENTRY entry;
-  explicit KeyAlreadyExistsException(const ENTRY& entry) : entry(entry) {}
+  typedef ENTRY_KEY_TYPE<ENTRY> T_KEY;
+  const T_KEY key;
+  explicit KeyAlreadyExistsException(const T_KEY& key) : key(key) {}
 };
 
 }  // namespace yoda

--- a/yoda/api/matrix/exceptions.h
+++ b/yoda/api/matrix/exceptions.h
@@ -44,7 +44,7 @@ struct CellNotFoundException : CellNotFoundCoverException {
   typedef ENTRY_COL_TYPE<ENTRY> T_COL;
   const T_ROW row;
   const T_COL col;
-  explicit CellNotFoundException(const T_ROW& row, const T_COL& col) : row(row), col(col) {}
+  CellNotFoundException(const T_ROW& row, const T_COL& col) : row(row), col(col) {}
 };
 
 // Exception types for the existence of a particular cell being a runtime error.
@@ -54,8 +54,11 @@ struct CellAlreadyExistsCoverException : bricks::Exception {};
 template <typename ENTRY>
 struct CellAlreadyExistsException : CellAlreadyExistsCoverException {
   typedef ENTRY T_ENTRY;
-  const ENTRY entry;
-  explicit CellAlreadyExistsException(const ENTRY& entry) : entry(entry) {}
+  typedef ENTRY_ROW_TYPE<ENTRY> T_ROW;
+  typedef ENTRY_COL_TYPE<ENTRY> T_COL;
+  const T_ROW row;
+  const T_COL col;
+  CellAlreadyExistsException(const T_ROW& row, const T_COL& col) : row(row), col(col) {}
 };
 
 }  // namespace yoda

--- a/yoda/api/matrix/matrix_entry.h
+++ b/yoda/api/matrix/matrix_entry.h
@@ -260,7 +260,8 @@ struct Container<YT, MatrixEntry<ENTRY>> {
       if (msg.on_failure) {  // Callback function defined.
         msg.on_failure();
       } else {  // Throw.
-        msg.pr.set_exception(std::make_exception_ptr(typename YET::T_CELL_ALREADY_EXISTS_EXCEPTION(msg.e)));
+        msg.pr.set_exception(std::make_exception_ptr(
+            typename YET::T_CELL_ALREADY_EXISTS_EXCEPTION(GetRow(msg.e), GetCol(msg.e))));
       }
     } else {
       forward_[GetRow(msg.e)][GetCol(msg.e)] = msg.e;
@@ -299,7 +300,7 @@ struct Container<YT, MatrixEntry<ENTRY>> {
       cell_exists = static_cast<bool>(rit->second.count(GetCol(entry)));
     }
     if (cell_exists) {
-      throw typename YET::T_CELL_ALREADY_EXISTS_EXCEPTION(entry);
+      throw typename YET::T_CELL_ALREADY_EXISTS_EXCEPTION(GetRow(entry), GetCol(entry));
     } else {
       forward_[GetRow(entry)][GetCol(entry)] = entry;
       transposed_[GetCol(entry)][GetRow(entry)] = entry;

--- a/yoda/metaprogramming.h
+++ b/yoda/metaprogramming.h
@@ -345,8 +345,8 @@ struct dispatch {
 
   template <typename... XS>
   typename std::enable_if<sfinae<XS...>(0), decltype(std::declval<T>()(std::declval<XS>()...))>::type
-  operator()(XS... params) {
-    return instance(params...);
+  operator()(XS&&... params) {
+    return instance(std::forward<XS>(params)...);
   }
 
   dispatch() = delete;
@@ -407,22 +407,22 @@ struct APICallsWrapper {
   // via the `using T1::operator(); using T2::operator();` trick.
   template <typename... XS>
   CWT<API, apicalls::Get, XS...> Get(XS&&... xs) {
-    return api(apicalls::Get(), xs...);
+    return api(apicalls::Get(), std::forward<XS>(xs)...);
   }
 
   template <typename... XS>
   CWT<API, apicalls::Add, XS...> Add(XS&&... xs) {
-    return api(apicalls::Add(), xs...);
+    return api(apicalls::Add(), std::forward<XS>(xs)...);
   }
 
   template <typename... XS>
   CWT<API, apicalls::AsyncGet, XS...> AsyncGet(XS&&... xs) {
-    return api(apicalls::AsyncGet(), xs...);
+    return api(apicalls::AsyncGet(), std::forward<XS>(xs)...);
   }
 
   template <typename... XS>
   CWT<API, apicalls::AsyncAdd, XS...> AsyncAdd(XS&&... xs) {
-    return api(apicalls::AsyncAdd(), xs...);
+    return api(apicalls::AsyncAdd(), std::forward<XS>(xs)...);
   }
 
   /// TODO(dkorolev): Remove this code.

--- a/yoda/test.cc
+++ b/yoda/test.cc
@@ -77,8 +77,8 @@ TEST(Yoda, CoverTest) {
 
     // `operator[]` syntax.
     EXPECT_EQ(42.0, static_cast<const KeyValueEntry&>(KVEntries[1]).value);
-    KeyValueEntry kve34;
-    ASSERT_THROW(kve34 = KVEntries[34], yoda::KeyNotFoundCoverException);
+    ASSERT_THROW(static_cast<void>(static_cast<const KeyValueEntry&>(KVEntries[34]).value),
+                 yoda::KeyNotFoundCoverException);
 
     auto mutable_kve = KeyEntry<KeyValueEntry>::Mutator(cw);
     mutable_kve.Add(KeyValueEntry(128, 512.0));

--- a/yoda/test_types.h
+++ b/yoda/test_types.h
@@ -41,6 +41,16 @@ struct KeyValueEntry : Padawan {
     Padawan::serialize(ar);
     ar(CEREAL_NVP(key), CEREAL_NVP(value));
   }
+
+  // Confirm that Yoda works with non-copyable types, as long as they are `std::move()`-d in.
+  // TODO(dkorolev): Sync up with Max on whether we need this. Chances are, we don't, at least now.
+  // void operator=(KeyValueEntry&& rhs) {
+  //   key = rhs.key;
+  //   value = rhs.value;
+  // }
+  // KeyValueEntry(KeyValueEntry&&) = default;
+  // KeyValueEntry(const KeyValueEntry&) = delete;
+  // void operator=(const KeyValueEntry&) = delete;
 };
 CEREAL_REGISTER_TYPE(KeyValueEntry);
 


### PR DESCRIPTION
Hi @mzhurovich ,

I started looking into whether it's easy / plausible to support non-copyable entries in Yoda.

(Keys and/or row/col keys should be copyable, but I was wondering if entries themselves should -- if they contain `unique_ptr<>`-s, only `std::move()`-ing them sounds like a good alternative.)

This work is not finished -- and I figured we have more important things -- but I'll create a pull request with related changed that look reasonable to me.

Thanks!
Dima
