### PR TITLE
Fix for type decaying.

### DIFF
--- a/sherlock.h
+++ b/sherlock.h
@@ -25,8 +25,6 @@ SOFTWARE.
 #ifndef SHERLOCK_H
 #define SHERLOCK_H
 
-#define BRICKS_MOCK_TIME
-
 #include "../Bricks/port.h"
 
 #include <vector>

--- a/yoda/docu/docu_2_reference_code.cc
+++ b/yoda/docu/docu_2_reference_code.cc
@@ -105,15 +105,47 @@ using bricks::strings::FromString;
     }
   };
   CEREAL_REGISTER_TYPE(PrimeCell);
-    
+  
+  // A more complex case of the using a non-POD type for the key.
+  struct StringIntTuple : Padawan {
+    std::string key;
+    int value;
+    StringIntTuple(const std::string& key = "", int value = 0) : key(key), value(value) {}
+    template <typename A>
+    void serialize(A& ar) {
+      Padawan::serialize(ar);
+      ar(CEREAL_NVP(key), CEREAL_NVP(value));
+    }
+  };
+  CEREAL_REGISTER_TYPE(StringIntTuple);
+  
 TEST(YodaDocu, Test) {
 const int port = FLAGS_yoda_docu_test_port;
 bricks::time::SetNow(static_cast<bricks::time::EPOCH_MILLISECONDS>(42));
 HTTP(port).ResetAllHandlers();
 
   // Define the `api` object.
-  typedef API<Dictionary<Prime>, MatrixEntry<PrimeCell>> PrimesAPI;
+  typedef API<Dictionary<StringIntTuple>,
+              Dictionary<Prime>,
+              MatrixEntry<PrimeCell>> PrimesAPI;
   PrimesAPI api("YodaExampleUsage");
+  
+  // Simple dictionary usecase, and a unit test for type system implementation.
+  api.Add(StringIntTuple("two", 2));
+  api.Add(static_cast<const StringIntTuple&>(StringIntTuple("three", 3)));
+  api.Transaction([](PrimesAPI::T_DATA data) {
+    data.Add(StringIntTuple("five", 5));
+    data.Add(static_cast<const StringIntTuple&>(
+      StringIntTuple("seven", 7)));
+    EXPECT_EQ(3, static_cast<StringIntTuple>(
+      data.Get(std::string("three"))).value);
+    EXPECT_EQ(5, static_cast<StringIntTuple>(
+      data.Get(static_cast<const std::string&>(std::string("five")))).value);
+  });
+  EXPECT_EQ(2, static_cast<StringIntTuple>(
+    api.Get(std::string("two")).Go()).value);
+  EXPECT_EQ(7, static_cast<StringIntTuple>(
+    api.Get(static_cast<const std::string&>(std::string("seven"))).Go()).value);
   
   // `2` is the first prime.
   // `.Go()` (or `.Wait()`) makes `Add()` a blocking call.
@@ -454,7 +486,7 @@ HTTP(port).ResetAllHandlers();
   api.ExposeViaHTTP(port, "/data");
   EXPECT_EQ(
 #if 1
-"{\"entry\":{\"polymorphic_id\":2147483649,\"polymorphic_name\":\"Prime\",\"ptr_wrapper\":{\"valid\":1,\"data\":{\"ms\":42,\"prime\":2,\"index\":1}}}}\n",
+"{\"entry\":{\"polymorphic_id\":2147483649,\"polymorphic_name\":\"StringIntTuple\",\"ptr_wrapper\":{\"valid\":1,\"data\":{\"ms\":42,\"key\":\"two\",\"value\":2}}}}\n",
 #else
     "... JSON represenation of the first entry ...",
 #endif

--- a/yoda/metaprogramming.h
+++ b/yoda/metaprogramming.h
@@ -289,19 +289,25 @@ template <typename YT>
 struct APICalls {
   static_assert(std::is_base_of<YodaTypesBase, YT>::value, "");
 
-  template <typename DATA, typename YET, typename E>
+  // `TopLevelAdd` accepts an undecayed type.
+  // It itself makes a copy of the entry to add, and passing in a non-decayed type
+  // enables using `std::forward<>`, choosing between copy and move semantics at compile time.
+  template <typename DATA, typename YET, typename UNDECAYED_ENTRY>
   struct TopLevelAdd {
-    const E entry;
-    TopLevelAdd(E&& entry) : entry(std::move(entry)) {}
+    const bricks::rmconstref<UNDECAYED_ENTRY> entry;
+    TopLevelAdd(UNDECAYED_ENTRY&& entry) : entry(std::forward<UNDECAYED_ENTRY>(entry)) {}
     void operator()(DATA data) const { YET::Mutator(data).Add(std::move(entry)); }
   };
 
-  template <typename DATA, typename YET, typename K>
+  // `TopLevelGet` accepts an undecayed type.
+  // It itself makes a copy of the key to query, and passing in a non-decayed type
+  // enables using `std::forward<>`, choosing between copy and move semantics at compile time.
+  template <typename DATA, typename YET, typename UNDECAYED_KEY>
   struct TopLevelGet {
-    const K key;
-    TopLevelGet(K&& key) : key(std::move(key)) {}
-    typedef decltype(
-        std::declval<decltype(YET::Accessor(std::declval<DATA>()))>().Get(std::declval<K>())) T_RETVAL;
+    const bricks::rmconstref<UNDECAYED_KEY> key;
+    TopLevelGet(UNDECAYED_KEY&& key) : key(std::forward<UNDECAYED_KEY>(key)) {}
+    typedef decltype(std::declval<decltype(YET::Accessor(std::declval<DATA>()))>().Get(
+        std::declval<bricks::rmconstref<UNDECAYED_KEY>>())) T_RETVAL;
     T_RETVAL operator()(DATA data) { return YET::Accessor(data).Get(std::move(key)); }
   };
 
@@ -374,21 +380,23 @@ struct APICalls {
   }
 
   // Helper method to wrap `Add()` into `Transaction()`.
-  template <typename ENTRY>
-  Future<void> Add(ENTRY&& entry) {
-    typedef bricks::rmconstref<ENTRY> SAFE_ENTRY;
-    typedef CWT<YodaContainer<YT>, type_inference::YETFromE<SAFE_ENTRY>> YET;
-    return Transaction(TopLevelAdd<YodaData<YT>, YET, SAFE_ENTRY>(std::forward<ENTRY>(entry)));
+  // Note: `TopLevelAdd` accepts an undecayed type.
+  // This is required to correctly handle both by-value and by-reference parameter types.
+  template <typename UNDECAYED_ENTRY>
+  Future<void> Add(UNDECAYED_ENTRY&& entry) {
+    typedef CWT<YodaContainer<YT>, type_inference::YETFromE<bricks::rmconstref<UNDECAYED_ENTRY>>> YET;
+    return Transaction(TopLevelAdd<YodaData<YT>, YET, UNDECAYED_ENTRY>(std::forward<UNDECAYED_ENTRY>(entry)));
   }
 
   // Helper method to wrap `Get()` into `Transaction()`. With one and with more than one parameter.
-  template <typename KEY>
-  Future<
-      EntryWrapper<typename CWT<YodaContainer<YT>, type_inference::YETFromK<bricks::rmconstref<KEY>>>::T_ENTRY>>
-  Get(KEY&& key) {
-    typedef bricks::rmconstref<KEY> SAFE_KEY;
-    typedef CWT<YodaContainer<YT>, type_inference::YETFromK<SAFE_KEY>> YET;
-    return Transaction(TopLevelGet<YodaData<YT>, YET, SAFE_KEY>(std::forward<KEY>(key)));
+  // Note: `TopLevelGet` accepts an undecayed type.
+  // This is required to correctly handle both by-value and by-reference parameter types.
+  template <typename UNDECAYED_KEY>
+  Future<EntryWrapper<
+      typename CWT<YodaContainer<YT>, type_inference::YETFromK<bricks::rmconstref<UNDECAYED_KEY>>>::T_ENTRY>>
+  Get(UNDECAYED_KEY&& key) {
+    typedef CWT<YodaContainer<YT>, type_inference::YETFromK<bricks::rmconstref<UNDECAYED_KEY>>> YET;
+    return Transaction(TopLevelGet<YodaData<YT>, YET, UNDECAYED_KEY>(std::forward<UNDECAYED_KEY>(key)));
   }
 
   template <typename KEY, typename... KEYS>
@@ -410,7 +418,8 @@ struct APICalls {
   Future<void> GetWithNext(KEY&& key, F&& f) {
     typedef bricks::rmconstref<KEY> SAFE_KEY;
     typedef CWT<YodaContainer<YT>, type_inference::YETFromK<SAFE_KEY>> YET;
-    return Transaction(TopLevelGet<YodaData<YT>, YET, SAFE_KEY>(std::forward<KEY>(key)), std::forward<F>(f));
+    return Transaction(TopLevelGet<YodaData<YT>, YET, SAFE_KEY>(std::forward<SAFE_KEY>(key)),
+                       std::forward<F>(f));
   }
 
   // Because I'm nice. :-) -- D.K.


### PR DESCRIPTION
Source: Apparently, doing a top-level `api.Get(*my_unique_ptr.get())` doesn't compile, since it tries to `std::move` a const reference.

Fixed it, then reproduced it on a simpler example, confirmed the example works, and pushing the fix.

Thanks,
Dima
